### PR TITLE
Filter candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Typically, ICE candidates provide the IP address and port from where the data is
 How to use
 ----
 
-#### `candidateToJson`: convert ICE Candidates to a Json object
+#### `candidateToJson`: convert ICE Candidates to a JSON object
 
 ```javascript
 var IceBreaker = require('ice-breaker');

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Ice-Breaker
 =========
 
-Ice-Breaker is a helper to parse WebRTC ICE candidate strings.
+Ice-Breaker is a set of helper methods to ease the WebRTC Media connection process.
 
 Context
 -----
-**WebRTC (Web Real-Time Communication)** is a collection of communications protocols and application programming interfaces that enable real-time communication over peer-to-peer connections. In order for these peers on different networks to locate one another, a form of discovery and media format negotiation must take place. This process is called signaling, and is where the ICE candidates enter the game.
+**WebRTC (Web Real-Time Communication)** is a collection of communications protocols and application programming interfaces that enable real-time communication over peer-to-peer connections. In order for these peers on different networks to locate one another, a form of discovery and media format negotiation must take place. Each peer will need to provide ICE candidates to the remote peer. The Session Description Protocol is used in the signaling process ([RFC-4566](https://tools.ietf.org/html/rfc4566)).
 
 Each ICE candidate describes a method which the originating peer is able to communicate, and each peer sends candidates in the order of discovery, until it runs out of suggestions. Once the two peers suggest a compatible candidate, media begins to flow.
 
@@ -13,14 +13,17 @@ Typically, ICE candidates provide the IP address and port from where the data is
 ```
 'candidate:7 1 UDP 1677722111 13.93.207.159 43399 typ srflx raddr 11.1.221.7 rport 43399'
 ```
-**Ice-Breaker** provides a method to parse this string into an object so the different fields can be easily inspected.
+**Ice-Breaker** provides methods to parse this string into an object so the different fields can be easily inspected, to filter SDP files so only candidates using a specific transport protocol are used, etc.
 
 How to use
 ----
+
+#### `candidateToJson`: convert ICE Candidates to a Json object
+
 ```javascript
 var IceBreaker = require('ice-breaker');
 
-var parsedCandidate = IceBreaker.toJson('candidate:7 1 UDP 1677722111 13.93.207.159 43399 typ srflx raddr 11.1.221.7 rport 43399');
+var parsedCandidate = IceBreaker.candidateToJson('candidate:7 1 UDP 1677722111 13.93.207.159 43399 typ srflx raddr 11.1.221.7 rport 43399');
 
 console.log('>>> My parsed ICE candidate: ', parsedCandidate);
 /* Should print:
@@ -33,6 +36,24 @@ console.log('>>> My parsed ICE candidate: ', parsedCandidate);
   candidateType: 'srflx',
   remoteConnectionAddress: '11.1.221.7',
   remotePort: '43399' }
+*/
+```
+#### `filterSDPCandidatesByTransport`: filter ICE candidates in an SDP file by transport protocol
+
+```javascript
+var IceBreaker = require('ice-breaker');
+
+// Please notice this is just a section of an SDP file
+var sdp = 'a=sendonly\r\n' +
+  'a=candidate:1 1 UDP 2013266431 1111::222:3aff:1111:4983 50791 typ host\r\n' +
+  'a=candidate:2 1 TCP 1019217151 1111::222:3aff:1111:4983 9 typ host tcptype active\r\n';
+      
+var filteredSdp = IceBreaker.filterSDPCandidatesByTransport(sdp, 'TCP');
+
+console.log('>>> My filtered SDP: ', filteredSdp);
+/* Should print:
+>>> My filtered SDP:  a=sendonly
+  a=candidate:2 1 TCP 1019217151 1111::222:3aff:1111:4983 9 typ host tcptype active
 */
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ice-Breaker is a set of helper methods to ease the WebRTC Media connection proce
 
 Context
 -----
-**WebRTC (Web Real-Time Communication)** is a collection of communications protocols and application programming interfaces that enable real-time communication over peer-to-peer connections. In order for these peers on different networks to locate one another, a form of discovery and media format negotiation must take place. Each peer will need to provide ICE candidates to the remote peer. The Session Description Protocol is used in the signaling process ([RFC-4566](https://tools.ietf.org/html/rfc4566)).
+**WebRTC (Web Real-Time Communication)** is a collection of communications protocols and application programming interfaces that enable real-time communication over peer-to-peer connections. In order for these peers on different networks to locate one another, a form of discovery and media format negotiation must take place. Each peer will need to provide ICE candidates to the remote peer. The Session Description Protocol is used in this signaling process ([RFC-4566](https://tools.ietf.org/html/rfc4566)).
 
 Each ICE candidate describes a method which the originating peer is able to communicate, and each peer sends candidates in the order of discovery, until it runs out of suggestions. Once the two peers suggest a compatible candidate, media begins to flow.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-breaker",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Parse WebRTC ICE Candidates string",
   "main": "lib/ice-breaker.js",
   "repository": {
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "nyc mocha --reporter spec",
-    "compile": "babel --presets es2015 -d lib/ src/",
+    "compile": "babel --presets env -d lib/ src/",
     "prepublish": "npm run compile"
   },
   "keywords": [
@@ -17,13 +17,16 @@
     "ice",
     "icecandidate",
     "stun",
-    "turn"
+    "turn",
+    "sdp",
+    "tcp",
+    "udp"
   ],
   "author": "Maria Fernandez <mariafehe@gmail.com>",
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.24.1",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "chai": "^4.0.2",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^15.0.1",
@@ -42,6 +45,8 @@
     "gulp-if": "^2.0.2",
     "mocha": "^3.4.2",
     "nyc": "^11.0.2",
+    "sinon": "^4.5.0",
+    "sinon-chai": "^3.0.0",
     "yargs": "^8.0.1"
   }
 }

--- a/src/ice-breaker.js
+++ b/src/ice-breaker.js
@@ -2,14 +2,50 @@
 
 const Constants = require('./constants');
 
+function _validateSDPTransportFilter(_filter) {
+  let filter = _filter;
+  if (!filter) return false;
+  if (typeof filter === 'string') {
+    filter = [filter];
+  }
+  if (Array.isArray(filter)) {
+    const validTransports = Object.keys(Constants.transport)
+      .map((k) => (Constants.transport[k]));
+    const isValid = filter.every((f) => (validTransports.indexOf(f) > -1));
+    return isValid ? filter : false;
+  }
+  return false;
+}
+
+function _getTransportFilterRegexp(filter) {
+  let filterRegexp;
+  filter.forEach((f) => {
+    if (!filterRegexp) filterRegexp = `\\b(${f})`;
+    else filterRegexp += `|(${f})`;
+  });
+  filterRegexp += '\\b';
+  return new RegExp(filterRegexp);
+}
+
 class IceBreaker {
+
+  /**
+  * @deprecated Use candidateToJson instead.
+  * Parses the received ICE candidate string into a JSON object
+  * @param {string} iceCandidate
+  * @returns {object} ICE candidate parsed
+  */
+  static toJson(iceCandidate) {
+    console.warn('This method is deprecated since version 0.0.6. Use `candidateToJson` instead.');
+    return this.candidateToJson(iceCandidate);
+  }
 
   /**
   * Parses the received ICE candidate string into a JSON object
   * @param {string} iceCandidate
   * @returns {object} ICE candidate parsed
   */
-  static toJson(iceCandidate) {
+  static candidateToJson(iceCandidate) {
     let iceCandidateJson = null;
 
     if (iceCandidate && typeof iceCandidate === 'string') {
@@ -46,6 +82,35 @@ class IceBreaker {
 
     return iceCandidateJson;
   }
+
+  /**
+  * Returns a new SDP containing only the ICE candidates that match the
+  * transport protocol provided in the filter.
+  * - The SDP must be a string, with every field in a new line. (see RFC-4566 -
+  *   https://tools.ietf.org/html/rfc4566 for SDP details).
+  * - The SDP will remain the same if it is not a string or no filter
+  *   is provided.
+  *
+  * @param {string} SDP to filter, with every field in a new line
+  * @param {string|Array} filter IceBreaker.transport (UDP|TCP)
+  */
+  static filterSDPCandidatesByTransport(sdp, _filter) {
+    let filteredSdp = sdp;
+    const filter = _validateSDPTransportFilter(_filter);
+    if (typeof sdp === 'string' && filter) {
+      let transportRegex = _getTransportFilterRegexp(filter);
+      const sdpLines = sdp.split('\n');
+      const filteredSdpLines = sdpLines.filter((l) => (
+        l.indexOf('a=candidate') > -1 &&
+        l.search(transportRegex) > -1 ||
+        l.indexOf('a=candidate') < 0
+      ));
+      filteredSdp = filteredSdpLines.join('\n');
+    }
+    return filteredSdp;
+  }
 }
+
+IceBreaker.transport = Constants.transport;
 
 module.exports = IceBreaker;


### PR DESCRIPTION
Filter ICE candidates in an SDP file by transport protocol (UDP, TCP) so the returned sdp file only contains the filtered candidates. Useful when a peer doesn't support Trickle ICE and is in a restricted network scenario.